### PR TITLE
fix: web build

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -101,6 +101,8 @@ jobs:
         with:
           channel: stable
           cache: true
+          # https://github.com/flutter/flutter/issues/160127
+          flutter-version: 3.24.5
 
       - name: Copy production config
         run: echo "${{ secrets.PRODUCTION_CONFIG }}" > lib/app_config.dart

--- a/packages/stream_chat_v1/web/index.html
+++ b/packages/stream_chat_v1/web/index.html
@@ -32,29 +32,12 @@
   <title>Stream Chat V1</title>
   <link rel="manifest" href="manifest.json">
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
-  </script>
   <!-- This script adds the flutter initialization JS code -->
   <script defer src="flutter.js"></script>
   <script defer src="sql-wasm.js"></script>
 </head>
 <body>
-<script>
-    window.addEventListener('load', function(ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        }
-      }).then(function(engineInitializer) {
-        return engineInitializer.initializeEngine();
-      }).then(function(appRunner) {
-        return appRunner.runApp();
-      });
-    });
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>
 


### PR DESCRIPTION
This pull request includes changes to update the Flutter version in the build workflow and to simplify the initialization script in the Stream Chat V1 web application.

### Build Workflow Updates:
* [`.github/workflows/build_nightly.yml`](diffhunk://#diff-66d23226f08f05ae86a7d6e764cf30f998e952aa9fd60bfba3dcf61572cf3db4R104-R105): Updated the Flutter version to 3.24.5 and added a reference to the relevant GitHub issue.

### Stream Chat V1 Web Application:
* [`packages/stream_chat_v1/web/index.html`](diffhunk://#diff-a7e25cdff649305b5e11023e1200c309bf7690d4bddca401c8b26c2a3b300fd5L35-R40): Removed the inline script for Flutter initialization and replaced it with a reference to `flutter_bootstrap.js`.