### PR TITLE
fix: pin chewie to 1.8.5

### DIFF
--- a/packages/stream_chat_v1/pubspec_overrides.yaml
+++ b/packages/stream_chat_v1/pubspec_overrides.yaml
@@ -24,3 +24,7 @@ dependency_overrides:
       url: https://github.com/GetStream/stream-chat-flutter.git
       ref: master
       path: packages/stream_chat_localizations
+
+  # The last chewie version that supports flutter 3.24.5
+  # Issue: https://github.com/fluttercommunity/chewie/issues/888
+  chewie: 1.8.5


### PR DESCRIPTION
This pull request includes a change to the `packages/stream_chat_v1/pubspec_overrides.yaml` file. The change adds a dependency override for the `chewie` package to ensure compatibility with Flutter version 3.24.5.

Dependency updates:

* [`packages/stream_chat_v1/pubspec_overrides.yaml`](diffhunk://#diff-b9ca8d1f1807bfff9578e21b44bbb338f47fe231f6cab5382ff2e61897b3de51R27-R30): Added a dependency override for `chewie` version 1.8.5 to support Flutter 3.24.5.